### PR TITLE
fix: 为Provider注册中心添加ID冲突检测

### DIFF
--- a/docs/Development_Tasks.md
+++ b/docs/Development_Tasks.md
@@ -581,6 +581,16 @@
   2. 标签文本在空间不足时允许省略，但不影响百分比和重置时间可读性
   3. `npm run typecheck` 通过
 
+### 5.5 线上问题修复（Issue #7）
+
+- [x] **操作**：
+  1. 调整 `src/renderer/providers/providerRegistry.ts`，在注册 Provider 前检查 `id` 是否已存在，禁止重复注册时静默覆盖
+  2. 新增 `src/renderer/providers/providerRegistry.test.ts`，验证默认 Provider 正常注册，且重复 ID 会抛出明确错误
+- [x] **验收标准**：
+  1. 同一个 `provider.id` 被重复注册时会抛出 `Provider <id> already registered`
+  2. 默认注册的 `zhipu`、`bailian` Provider 仍可通过注册中心正常获取
+  3. `npm run test -- providerRegistry.test.ts` 与 `npm run typecheck` 通过
+
 ## 阶段 6：打包与发布
 
 > **前置依赖**：阶段 5 测试全部通过

--- a/src/renderer/providers/providerRegistry.test.ts
+++ b/src/renderer/providers/providerRegistry.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { IProvider } from '../../shared/types'
+
+async function loadProviderRegistry() {
+  vi.resetModules()
+  return import('./providerRegistry')
+}
+
+function createProvider(id: string): IProvider {
+  return {
+    id,
+    name: `Provider ${id}`,
+    icon: '',
+    getAuthFields: () => [],
+    fetchUsage: async () => ({
+      providerId: id,
+      dimensions: [],
+      lastUpdated: Date.now()
+    })
+  }
+}
+
+describe('providerRegistry', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('should expose auto-registered providers', async () => {
+    const { getAllProviders, getProvider } = await loadProviderRegistry()
+
+    expect(getProvider('zhipu')).toBeDefined()
+    expect(getProvider('bailian')).toBeDefined()
+    expect(getAllProviders().map((provider) => provider.id)).toEqual(['zhipu', 'bailian'])
+  })
+
+  it('should throw when registering a duplicate provider id', async () => {
+    const { registerProvider } = await loadProviderRegistry()
+
+    expect(() => registerProvider(createProvider('zhipu'))).toThrowError(
+      'Provider zhipu already registered'
+    )
+  })
+})

--- a/src/renderer/providers/providerRegistry.ts
+++ b/src/renderer/providers/providerRegistry.ts
@@ -6,6 +6,10 @@ import zhipuProvider from './zhipuProvider'
 const providerRegistry = new Map<string, IProvider>()
 
 export function registerProvider(provider: IProvider): void {
+  if (providerRegistry.has(provider.id)) {
+    throw new Error(`Provider ${provider.id} already registered`)
+  }
+
   providerRegistry.set(provider.id, provider)
 }
 


### PR DESCRIPTION
## 变更说明\n- 为 egisterProvider 增加重复 Provider ID 冲突检测，避免静默覆盖\n- 新增 providerRegistry 回归测试，覆盖默认注册与重复注册报错场景\n- 在 docs/Development_Tasks.md 勾选 Issue #7 的修复与验收项\n\n## 验证\n- 
pm run test -- src/renderer/providers/providerRegistry.test.ts\n- 
pm run test -- src/renderer/providers/zhipuProvider.test.ts\n- 
pm run typecheck\n\nCloses #7