### PR TITLE
fix: 修复收缩态展示维度单选逻辑

### DIFF
--- a/docs/Development_Tasks.md
+++ b/docs/Development_Tasks.md
@@ -602,6 +602,19 @@
   2. 拖拽过程中位置更新经过 `requestAnimationFrame` 节流，避免每次 `mousemove` 都触发状态更新
   3. `npm run typecheck` 与 `npm run test` 通过
 
+### 5.7 线上问题修复（Issue #16）
+
+- [x] **操作**：
+  1. 调整 `src/renderer/context/AppContext.tsx` 的维度勾选逻辑，将同一厂商的 `checkedDimensions` 收敛为唯一展示项，并兼容旧配置中存在多个维度同时勾选的情况
+  2. 调整 `src/renderer/components/ExpandedView.tsx` 的展开态交互，使点击未选中的维度时直接替换当前展示项，且已选中的维度不会被取消为“全不选”
+  3. 补充 `src/renderer/context/AppContext.test.ts` 回归测试，覆盖旧配置收敛、单选替换和唯一选中态同步
+- [x] **验收标准**：
+  1. 同一厂商在展开态中最多只能勾选一个维度
+  2. 点击另一个维度后，旧选项自动取消，新选项成为唯一选中项
+  3. 旧配置若存在多个 `checkedDimensions`，加载或刷新后会稳定收敛为一个有效展示项
+  4. 收缩态始终与唯一选中维度保持一致
+  5. `npm run typecheck` 与 `npm test` 通过
+
 ## 阶段 6：打包与发布
 
 > **前置依赖**：阶段 5 测试全部通过

--- a/src/renderer/components/ExpandedView.tsx
+++ b/src/renderer/components/ExpandedView.tsx
@@ -134,10 +134,13 @@ function ExpandedView({
             </span>
           </button>
 
-          <div className="expanded-view__dimensions">
+          <div
+            className="expanded-view__dimensions"
+            role="radiogroup"
+            aria-label={`${providerMeta.name} 折叠态展示维度`}
+          >
             {provider.dimensions.map((dimension) => {
-              const isChecked = config.checkedDimensions.includes(dimension.id)
-              const isLastCheckedDimension = isChecked && config.checkedDimensions.length === 1
+              const isChecked = config.checkedDimensions[0] === dimension.id
 
               return (
                 <div
@@ -156,14 +159,13 @@ function ExpandedView({
                   >
                     <button
                       type="button"
-                      role="checkbox"
+                      role="radio"
                       aria-checked={isChecked}
-                      aria-label={`在折叠态显示 ${providerMeta.name} 的 ${dimension.label}`}
+                      aria-label={`将 ${providerMeta.name} 的 ${dimension.label} 设为折叠态展示项`}
                       className={`expanded-view__checkbox-wrap${
                         isChecked ? ' expanded-view__checkbox-wrap--checked' : ''
                       }`}
                       data-no-drag="true"
-                      disabled={isLastCheckedDimension}
                       onMouseDown={stopInteractionPropagation}
                       onClick={(event) => {
                         event.stopPropagation()

--- a/src/renderer/context/AppContext.test.ts
+++ b/src/renderer/context/AppContext.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AppConfig, AppState, ProviderUsageData } from '../../shared/types'
+import { appReducer, normalizeCheckedDimensions } from './AppContext'
+
+function createProviderUsageData(): ProviderUsageData {
+  return {
+    providerId: 'zhipu',
+    dimensions: [
+      {
+        id: 'token_5h',
+        label: '每5小时 Token',
+        usedPercent: 31,
+        used: 62000,
+        total: 200000,
+        resetTime: '12:00',
+        isChecked: true
+      },
+      {
+        id: 'mcp_monthly',
+        label: 'MCP 每月额度',
+        usedPercent: 12,
+        used: 240,
+        total: 2000,
+        resetTime: '03-27',
+        isChecked: false
+      }
+    ],
+    lastUpdated: 1
+  }
+}
+
+function createConfig(checkedDimensions: string[]): AppConfig {
+  return {
+    providers: [
+      {
+        providerId: 'zhipu',
+        auth: {
+          authToken: 'sk-test'
+        },
+        checkedDimensions,
+        enabled: true
+      }
+    ],
+    refreshInterval: 60,
+    windowPosition: { x: 100, y: 100 },
+    windowState: 'normal',
+    isExpanded: false
+  }
+}
+
+function createState(checkedDimensions: string[]): AppState {
+  const usageData = createProviderUsageData()
+
+  return {
+    config: createConfig(checkedDimensions),
+    usageData: new Map([[usageData.providerId, usageData]]),
+    isLoading: false,
+    settingsOpen: false
+  }
+}
+
+describe('normalizeCheckedDimensions', () => {
+  it('keeps only the first valid checked dimension from legacy multi-select config', () => {
+    expect(
+      normalizeCheckedDimensions(
+        ['missing', 'mcp_monthly', 'token_5h'],
+        ['token_5h', 'mcp_monthly']
+      )
+    ).toEqual(['mcp_monthly'])
+  })
+
+  it('falls back to the first available dimension when no checked dimension remains valid', () => {
+    expect(normalizeCheckedDimensions(['missing'], ['token_5h', 'mcp_monthly'])).toEqual([
+      'token_5h'
+    ])
+  })
+})
+
+describe('appReducer', () => {
+  it('replaces the previously selected dimension instead of accumulating multiple selections', () => {
+    const nextState = appReducer(createState(['token_5h']), {
+      type: 'TOGGLE_DIMENSION',
+      payload: {
+        providerId: 'zhipu',
+        dimensionId: 'mcp_monthly'
+      }
+    })
+
+    expect(nextState.config.providers[0]?.checkedDimensions).toEqual(['mcp_monthly'])
+    expect(
+      nextState.usageData.get('zhipu')?.dimensions.map((dimension) => ({
+        id: dimension.id,
+        isChecked: dimension.isChecked
+      }))
+    ).toEqual([
+      { id: 'token_5h', isChecked: false },
+      { id: 'mcp_monthly', isChecked: true }
+    ])
+  })
+
+  it('keeps the selected dimension when the current option is clicked again', () => {
+    const nextState = appReducer(createState(['token_5h']), {
+      type: 'TOGGLE_DIMENSION',
+      payload: {
+        providerId: 'zhipu',
+        dimensionId: 'token_5h'
+      }
+    })
+
+    expect(nextState.config.providers[0]?.checkedDimensions).toEqual(['token_5h'])
+  })
+
+  it('normalizes loaded legacy config to a single checked dimension', () => {
+    const initialState = createState(['token_5h'])
+
+    const nextState = appReducer(initialState, {
+      type: 'SET_CONFIG',
+      payload: {
+        providers: [
+          {
+            providerId: 'zhipu',
+            auth: {
+              authToken: 'sk-test'
+            },
+            checkedDimensions: ['token_5h', 'mcp_monthly'],
+            enabled: true
+          }
+        ]
+      }
+    })
+
+    expect(nextState.config.providers[0]?.checkedDimensions).toEqual(['token_5h'])
+  })
+
+  it('collapses legacy multi-select config to one valid dimension when usage data arrives', () => {
+    const nextState = appReducer(createState(['missing', 'mcp_monthly', 'token_5h']), {
+      type: 'SET_USAGE_DATA',
+      payload: createProviderUsageData()
+    })
+
+    expect(nextState.config.providers[0]?.checkedDimensions).toEqual(['mcp_monthly'])
+    expect(
+      nextState.usageData.get('zhipu')?.dimensions.map((dimension) => ({
+        id: dimension.id,
+        isChecked: dimension.isChecked
+      }))
+    ).toEqual([
+      { id: 'token_5h', isChecked: false },
+      { id: 'mcp_monthly', isChecked: true }
+    ])
+  })
+})

--- a/src/renderer/context/AppContext.tsx
+++ b/src/renderer/context/AppContext.tsx
@@ -32,6 +32,56 @@ const DEFAULT_CONFIG: AppConfig = {
   isExpanded: false
 }
 
+function dedupeDimensionIds(dimensionIds: string[]): string[] {
+  return Array.from(new Set(dimensionIds.filter((dimensionId) => dimensionId.trim().length > 0)))
+}
+
+export function normalizeCheckedDimensions(
+  checkedDimensions: string[],
+  availableDimensionIds: string[]
+): string[] {
+  const uniqueCheckedDimensions = dedupeDimensionIds(checkedDimensions)
+
+  if (availableDimensionIds.length === 0) {
+    return uniqueCheckedDimensions[0] ? [uniqueCheckedDimensions[0]] : []
+  }
+
+  const availableDimensionIdSet = new Set(availableDimensionIds)
+
+  for (const dimensionId of uniqueCheckedDimensions) {
+    if (availableDimensionIdSet.has(dimensionId)) {
+      return [dimensionId]
+    }
+  }
+
+  return availableDimensionIds[0] ? [availableDimensionIds[0]] : []
+}
+
+function syncUsageDataCheckedDimensions(
+  usageData: ProviderUsageData,
+  checkedDimensions: string[]
+): ProviderUsageData {
+  const checkedDimensionSet = new Set(checkedDimensions)
+
+  return {
+    ...usageData,
+    dimensions: usageData.dimensions.map((dimension) => ({
+      ...dimension,
+      isChecked: checkedDimensionSet.has(dimension.id)
+    }))
+  }
+}
+
+function normalizeProvidersConfig(config: AppConfig): AppConfig {
+  return {
+    ...config,
+    providers: config.providers.map((providerConfig) => ({
+      ...providerConfig,
+      checkedDimensions: normalizeCheckedDimensions(providerConfig.checkedDimensions, [])
+    }))
+  }
+}
+
 function serializeConfig(config: AppConfig): string {
   return JSON.stringify(config)
 }
@@ -46,15 +96,15 @@ function createDefaultState(): AppState {
 }
 
 function mergeConfig(currentConfig: AppConfig, patch: Partial<AppConfig>): AppConfig {
-  return {
+  return normalizeProvidersConfig({
     ...currentConfig,
     ...patch,
     windowPosition: patch.windowPosition ?? currentConfig.windowPosition,
     providers: patch.providers ?? currentConfig.providers
-  }
+  })
 }
 
-function appReducer(state: AppState, action: AppAction): AppState {
+export function appReducer(state: AppState, action: AppAction): AppState {
   switch (action.type) {
     case 'SET_CONFIG':
       return {
@@ -65,29 +115,24 @@ function appReducer(state: AppState, action: AppAction): AppState {
       const providerConfig = state.config.providers.find(
         (config) => config.providerId === action.payload.providerId
       )
-      const shouldSeedCheckedDimensions =
+      const availableDimensionIds = action.payload.dimensions.map((dimension) => dimension.id)
+      const checkedDimensions = providerConfig
+        ? normalizeCheckedDimensions(providerConfig.checkedDimensions, availableDimensionIds)
+        : []
+      const shouldSyncCheckedDimensions =
         Boolean(providerConfig) &&
-        providerConfig!.checkedDimensions.length === 0 &&
-        action.payload.dimensions.length > 0
-      const checkedDimensions = shouldSeedCheckedDimensions
-        ? [action.payload.dimensions[0].id]
-        : (providerConfig?.checkedDimensions ?? [])
+        checkedDimensions.length === 1 &&
+        providerConfig!.checkedDimensions.join('|') !== checkedDimensions.join('|')
       const nextPayload =
         checkedDimensions.length > 0
-          ? {
-              ...action.payload,
-              dimensions: action.payload.dimensions.map((dimension) => ({
-                ...dimension,
-                isChecked: checkedDimensions.includes(dimension.id)
-              }))
-            }
+          ? syncUsageDataCheckedDimensions(action.payload, checkedDimensions)
           : action.payload
       const nextUsageData = new Map(state.usageData)
       nextUsageData.set(action.payload.providerId, nextPayload)
 
       return {
         ...state,
-        config: shouldSeedCheckedDimensions
+        config: shouldSyncCheckedDimensions
           ? {
               ...state.config,
               providers: state.config.providers.map((config) =>
@@ -124,17 +169,13 @@ function appReducer(state: AppState, action: AppAction): AppState {
           return config
         }
 
-        const isChecked = config.checkedDimensions.includes(dimensionId)
-
-        if (isChecked && config.checkedDimensions.length === 1) {
+        if (config.checkedDimensions[0] === dimensionId) {
           return config
         }
 
         return {
           ...config,
-          checkedDimensions: isChecked
-            ? config.checkedDimensions.filter((item) => item !== dimensionId)
-            : [...config.checkedDimensions, dimensionId]
+          checkedDimensions: [dimensionId]
         }
       })
 
@@ -143,18 +184,12 @@ function appReducer(state: AppState, action: AppAction): AppState {
 
       if (providerUsage) {
         const activeConfig = nextProviders.find((config) => config.providerId === providerId)
-        const checkedDimensions = new Set(activeConfig?.checkedDimensions ?? [])
+        const checkedDimensions = activeConfig?.checkedDimensions ?? []
 
         nextUsageData.set(providerId, {
-          ...providerUsage,
-          dimensions: providerUsage.dimensions.map((dimension) =>
-            checkedDimensions.size > 0
-              ? {
-                  ...dimension,
-                  isChecked: checkedDimensions.has(dimension.id)
-                }
-              : dimension
-          )
+          ...(checkedDimensions.length > 0
+            ? syncUsageDataCheckedDimensions(providerUsage, checkedDimensions)
+            : providerUsage)
         })
       }
 

--- a/src/renderer/hooks/useAutoRefresh.ts
+++ b/src/renderer/hooks/useAutoRefresh.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react'
 
 import type { ProviderConfig, ProviderUsageData } from '../../shared/types'
-import { useAppContext } from '../context/AppContext'
+import { normalizeCheckedDimensions, useAppContext } from '../context/AppContext'
 import { getProvider } from '../providers/providerRegistry'
 
 const RETRY_DELAYS_MS = [30_000, 60_000, 300_000] as const
@@ -16,11 +16,10 @@ function getRetryDelayMs(failureCount: number, intervalSeconds: number): number 
 }
 
 function getCheckedDimensions(config: ProviderConfig, data: ProviderUsageData): string[] {
-  if (config.checkedDimensions.length > 0) {
-    return config.checkedDimensions
-  }
-
-  return data.dimensions[0] ? [data.dimensions[0].id] : []
+  return normalizeCheckedDimensions(
+    config.checkedDimensions,
+    data.dimensions.map((dimension) => dimension.id)
+  )
 }
 
 function applyCheckedDimensions(


### PR DESCRIPTION
## 摘要
- 将展开态维度选择从多选收敛为单选，点击新维度时直接替换当前折叠态展示项
- 在配置加载与用量刷新阶段兼容旧的多选配置，自动收敛为唯一有效维度
- 补充 AppContext 回归测试，并在 docs/Development_Tasks.md 记录 Issue #16 验收

## 验证
- npm test
- npm run typecheck
- npm run lint（当前仓库存在大量历史 prettier/prettier CRLF warnings，本次未新增错误）

Closes #16